### PR TITLE
update golang.org/x/sys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/urfave/cli v1.22.0
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,9 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
With old version of x/sys build fails.

See https://stackoverflow.com/questions/71507321/go-1-18-build-error-on-mac-unix-syscall-darwin-1-13-go253-golinkname-mus

go get -u golang.org/x/sys

```bash
AKAMAI_LOG=debug  akamai install cli-dns
 DEBUG[0000] INSTALL START             command=install
Attempting to fetch command from https://github.com/akamai/cli-dns.git... ... [OK]
 DEBUG[0000] Go binary found: /opt/homebrew/bin/go command=install
 DEBUG[0000] /opt/homebrew/bin/go version: go version go1.18.2 darwin/arm64 command=install
  INFO[0000] go.sum found, running go module package manager command=install
Installing... [=         ]  DEBUG[0000] Unable to build binary (akamai-dns):
# golang.org/x/sys/unix
../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/syscall_darwin.1_13.go:25:3: //go:linkname must refer to declared function or variable
../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.1_13.go:27:3: //go:linkname must refer to declared function or variable
../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.1_13.go:40:3: //go:linkname must refer to declared function or variable
../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:28:3: //go:linkname must refer to declared function or variable
../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:43:3: //go:linkname must refer to declared function or variable
../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:59:3: //go:linkname must refer to declared function or variable
../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:75:3: //go:linkname must refer to declared function or variable
../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:90:3: //go:linkname must refer to declared function or variable
../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:105:3: //go:linkname must refer to declared function or variable
../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:121:3: //go:linkname must refer to declared function or variable
../../pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:121:3: too many errors
 command=install
Installing... ... [WARN]
unable to build binary: dns
  WARN[0000] unable to build binary: dns command=install
```

```bash
$ go version
go version go1.18.2 darwin/arm64
```