### PR TITLE
Release/0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Release Notes
+
+## Version 0.5.0 (May 10, 2023)
+
+### Features/Enhancements
+
+* Add M1 support
+* Migrate to go 1.18

--- a/README.md
+++ b/README.md
@@ -25,18 +25,13 @@ for your system, or by cloning this repository and compiling it yourself.
 
 ### Compiling from Source
 
-If you want to compile the package from source, you will need Go 1.14 or later installed:
+If you want to compile the package from source, you will need Go 1.18 or later installed:
 
-1. Fetch the package:  
-  `go get github.com/akamai/cli-dns`
-2. Change to the package directory:  
-  `cd $GOPATH/src/github.com/akamai/cli-dns`
-3. Install dependencies:  
-  `go mod vendor`
-4. Compile the binary:
-  - Linux/macOS/*nix: `go build -mod=vendor -o akamai-dns`
-  - Windows: `go build -mod=vendor -o akamai-dns.exe`
-5. Move the binary (`akamai-dns` or `akamai-dns.exe`) in to your `PATH`
+1. Create a clone of the target repository:
+   `git clone https://github.com/akamai/cli-dns.git`
+2. Change to the package directory and compile the binary::
+  - Linux/macOS/*nix: `go build -o akamai-dns`
+  - Windows: `go build -o akamai-dns.exe`
 
 ## Command Summary
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you want to compile the package from source, you will need Go 1.18 or later i
 
 1. Create a clone of the target repository:
    `git clone https://github.com/akamai/cli-dns.git`
-2. Change to the package directory and compile the binary::
+2. Change to the package directory and compile the binary:
   - Linux/macOS/*nix: `go build -o akamai-dns`
   - Windows: `go build -o akamai-dns.exe`
 

--- a/akamai-dns.go
+++ b/akamai-dns.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	VERSION = "0.4.0"
+	VERSION = "0.5.0"
 )
 
 func main() {

--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,8 @@ check_version $1
 
 mkdir -p build
 
+GOOS=darwin GOARCH=arm64 go build -o build/akamai-dns-$1-macarm64 .
+shasum -a 256 build/akamai-dns-$1-macarm64 | awk '{print $1}' > build/akamai-dns-$1-macarm64.sig
 GOOS=darwin GOARCH=amd64 go build -o build/akamai-dns-$1-macamd64 .
 shasum -a 256 build/akamai-dns-$1-macamd64 | awk '{print $1}' > build/akamai-dns-$1-macamd64.sig
 GOOS=linux GOARCH=amd64 go build -o build/akamai-dns-$1-linuxamd64 .

--- a/cli.json
+++ b/cli.json
@@ -1,11 +1,11 @@
 {
   "requirements": {
-    "go": "1.14.0"
+    "go": "1.18.0"
   },
   "commands": [
     {
       "name": "dns",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "description": "Manage DNS zones with Edge DNS",
       "bin": "https://github.com/akamai/cli-dns/releases/download/{{.Version}}/akamai-{{.Name}}-{{.Version}}-{{.OS}}{{.Arch}}{{.BinSuffix}}",
       "auto-complete": true

--- a/command_add_record.go
+++ b/command_add_record.go
@@ -128,7 +128,7 @@ func cmdCreateRecord(c *cli.Context) error {
 		record.(*dns.MxRecord).TTL = c.Int("ttl")
 
 		if !strings.HasSuffix(c.String("target"), ".") {
-			record.(*dns.CnameRecord).Target += "."
+			record.(*dns.MxRecord).Target += "."
 		}
 	case "NAPTR":
 		record = dns.NewNaptrRecord()
@@ -149,7 +149,7 @@ func cmdCreateRecord(c *cli.Context) error {
 		record.(*dns.NsRecord).TTL = c.Int("ttl")
 
 		if !strings.HasSuffix(c.String("target"), ".") {
-			record.(*dns.CnameRecord).Target += "."
+			record.(*dns.NsRecord).Target += "."
 		}
 	case "NSEC3":
 		record = dns.NewNsec3Record()

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,28 @@
 module github.com/akamai/cli-dns
 
-go 1.14
+go 1.18
 
 require (
-	github.com/akamai/AkamaiOPEN-edgegrid-golang v1.0.0
+	github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2
 	github.com/akamai/cli-common-golang v0.0.0-20210716202303-5a2a24172430
-	github.com/briandowns/spinner v1.11.1 // indirect
 	github.com/dshafik/gozone v0.0.0-20180309042724-80dfb510e448
 	github.com/fatih/color v1.7.0
 	github.com/mattn/go-isatty v0.0.11
-	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/urfave/cli v1.22.0
+)
+
+require (
+	github.com/briandowns/spinner v1.11.1 // indirect
+	github.com/cpuguy83/go-md2man v1.0.10 // indirect
+	github.com/google/uuid v1.1.1 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/mattn/go-runewidth v0.0.4 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/russross/blackfriday v1.5.2 // indirect
+	github.com/sirupsen/logrus v1.4.2 // indirect
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+	gopkg.in/ini.v1 v1.51.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/akamai/AkamaiOPEN-edgegrid-golang v1.0.0 h1:FJF58TWBaQnGqTIcziIP5/z3TTqWUn8fh26z03oZE2c=
-github.com/akamai/AkamaiOPEN-edgegrid-golang v1.0.0/go.mod h1:kX6YddBkXqqywAe8c9LyvgTCyFuZCTMF4cRPQhc3Fy8=
+github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2 h1:F1j7z+/DKEsYqZNoxC6wvfmaiDneLsQOFQmuq9NADSY=
+github.com/akamai/AkamaiOPEN-edgegrid-golang v1.2.2/go.mod h1:QlXr/TrICfQ/ANa76sLeQyhAJyNR9sEcfNuZBkY9jgY=
 github.com/akamai/cli-common-golang v0.0.0-20210716202303-5a2a24172430 h1:r3rIAjiTm3sghyvwQ5H6S2/JIsFoscysECo4wrGBaZU=
 github.com/akamai/cli-common-golang v0.0.0-20210716202303-5a2a24172430/go.mod h1:zCub6Q5dfWVvCjXQubVbepcb4DT2AIEPKSxWaTsydRU=
 github.com/briandowns/spinner v1.11.1 h1:OixPqDEcX3juo5AjQZAnFPbeUA0jvkp2qzB5gOZJ/L0=
@@ -34,7 +34,6 @@ github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
@@ -54,8 +53,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/cli v1.22.0 h1:8nz/RUUotroXnOpYzT/Fy3sBp+2XEbXaY641/s3nbFI=
 github.com/urfave/cli v1.22.0/go.mod h1:b3D7uWrF2GilkNgYpgcg6J+JMUw7ehmNkE8sZdliGLc=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
@@ -70,11 +69,11 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/h2non/gock.v1 v1.0.15 h1:SzLqcIlb/fDfg7UvukMpNcWsu7sI5tWwL+KCATZqks0=
 gopkg.in/h2non/gock.v1 v1.0.15/go.mod h1:sX4zAkdYX1TRGJ2JY156cFspQn4yRWn6p9EMdODlynE=
 gopkg.in/ini.v1 v1.51.1 h1:GyboHr4UqMiLUybYjd22ZjQIKEJEpgtLXtuGbR21Oho=
 gopkg.in/ini.v1 v1.51.1/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Version 0.5.0 (May 10, 2023)

### Features/Enhancements

* Add M1 support
* Migrate to go 1.18